### PR TITLE
Remove Custom Launcher3QuickStep(Google/Mock) launcher on Omnirom

### DIFF
--- a/customize_setup.sh
+++ b/customize_setup.sh
@@ -98,6 +98,8 @@ REPLACE="
 /system/system_ext/priv-app/Lawnchair
 /system/system_ext/priv-app/PixelLauncherRelease
 /system/system_ext/priv-app/Launcher3QuickStep
+/system/system_ext/priv-app/Launcher3QuickStepGoogle
+/system/system_ext/priv-app/Launcher3QuickStepMock
 /system/system_ext/priv-app/ArrowLauncher
 /system/system_ext/priv-app/WallpaperPickerGoogleRelease
 /system/product/overlay/ThemedIconsOverlay.apk

--- a/manual_setup.sh
+++ b/manual_setup.sh
@@ -95,6 +95,8 @@ REPLACE="
 /system/product/overlay/CustomPixelLauncherOverlay
 /system/system_ext/priv-app/NexusLauncherRelease
 /system/system_ext/priv-app/TrebuchetQuickStep
+/system/system_ext/priv-app/Launcher3QuickStepGoogle
+/system/system_ext/priv-app/Launcher3QuickStepMock
 /system/system_ext/priv-app/Lawnchair
 /system/system_ext/priv-app/PixelLauncherRelease
 /system/system_ext/priv-app/Launcher3QuickStep

--- a/offline_setup.sh
+++ b/offline_setup.sh
@@ -88,6 +88,8 @@ REPLACE="
 /system/system_ext/priv-app/Lawnchair
 /system/system_ext/priv-app/PixelLauncherRelease
 /system/system_ext/priv-app/Launcher3QuickStep
+/system/system_ext/priv-app/Launcher3QuickStepGoogle
+/system/system_ext/priv-app/Launcher3QuickStepMock
 /system/system_ext/priv-app/ArrowLauncher
 /system/system_ext/priv-app/WallpaperPickerGoogleRelease
 /system/product/overlay/ThemedIconsOverlay.apk

--- a/online_setup.sh
+++ b/online_setup.sh
@@ -88,6 +88,8 @@ REPLACE="
 /system/system_ext/priv-app/Lawnchair
 /system/system_ext/priv-app/PixelLauncherRelease
 /system/system_ext/priv-app/Launcher3QuickStep
+/system/system_ext/priv-app/Launcher3QuickStepGoogle
+/system/system_ext/priv-app/Launcher3QuickStepMock
 /system/system_ext/priv-app/ArrowLauncher
 /system/system_ext/priv-app/WallpaperPickerGoogleRelease
 /system/product/overlay/ThemedIconsOverlay.apk


### PR DESCRIPTION
Omnirom use an custom Launcher3 folder name so the installer cant override it and break PLE